### PR TITLE
Script as the regular sh file

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,58 @@ example setting `ignore_errors` and `no_auto` options:
         options: {ignore_errors: true, no_auto: true}
 ```
 
+### Script Execution
+
+SimploTask allows executing scripts on remote hosts, or locally if `options.local` is set to true. Scripts can be executed in two different ways, depending on whether they are single-line or multi-line scripts.
+
+**Single-line Script Execution**
+
+For single-line scripts, they are executed directly inside the shell with the optional parameters set to the command line. For example:
+
+```yaml
+  commands:
+      - name: some command
+        script: ls -laR /tmp
+        env: {FOO: bar, BAR: qux} 
+```        
+this will be executed as: `FOO='bar' BAR='qux'ls -laR /tmp FOO=bar BAR=qux` inside the shell on the remote host(s), i.e. `sh -c "FOO='bar' BAR='qux'ls -laR /tmp FOO=bar BAR=qux"`.
+
+**Multi-line Script Execution**
+
+For multi-line scripts, SimploTask creates a temporary script containing all the commands, uploads it to the remote host (or keeps it locally if `options.local` is set to true), and executes the script. Environment variables are set inside the script, allowing you to create complex scripts that include setting variables, conditionals, loops, and other advanced functionality. Scripts run with "set -e" to fail on error. For example:
+
+```yaml
+commands:
+  - name: multi_line_script
+    script: |
+      touch /tmp/file1
+      echo "Hello World" > /tmp/file2
+      echo "Executing loop..."
+      for i in {1..5}; do
+        echo "Iteration $i"
+      done
+      echo "All done! $FOO $BAR
+    env: {FOO: bar, BAR: qux}
+```
+
+this will create a temporary script on the remote host(s) with the following content and execute it:
+
+```bash
+#!/bin/sh
+set -e
+export FOO='bar'
+export BAR='qux'
+touch /tmp/file1
+echo "Hello World" > /tmp/file2
+echo "Executing loop..."
+for i in {1..5}; do
+  echo "Iteration $i"
+done
+echo "All done! $FOO $BAR"
+```
+
+By using this approach, SimploTask enables users to write and execute more complex scripts, providing greater flexibility and power in managing remote hosts or local environments.
+
 ## Targets
 
 Targets are used to define the remote hosts to execute the tasks on. Targets can be defined in the playbook file or passed as a command-line argument. The following target types are supported:

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -242,7 +241,7 @@ func TestCmd_getScriptFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reader := tt.cmd.getScriptFile()
-			scriptContentBytes, err := ioutil.ReadAll(reader)
+			scriptContentBytes, err := io.ReadAll(reader)
 			assert.NoError(t, err)
 			scriptContent := string(scriptContentBytes)
 			assert.Equal(t, tt.expected, scriptContent)

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -2,8 +2,11 @@ package config
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,6 +73,109 @@ func TestPlayBook_TaskOverrideEnv(t *testing.T) {
 }
 
 func TestCmd_GetScript(t *testing.T) {
+	testCases := []struct {
+		name             string
+		cmd              *Cmd
+		expectedScript   string
+		expectedContents []string
+	}{
+		{
+			name: "single line command without environment variables",
+			cmd: &Cmd{
+				Script: "echo 'Hello, World!'",
+			},
+			expectedScript:   `sh -c "echo 'Hello, World!'"`,
+			expectedContents: nil,
+		},
+		{
+			name: "multiline command without environment variables",
+			cmd: &Cmd{
+				Script: `echo 'Hello, World!'
+echo 'Goodbye, World!'`,
+			},
+			expectedScript: "",
+			expectedContents: []string{
+				"#!/bin/sh",
+				"set -e",
+				"echo 'Hello, World!'",
+				"echo 'Goodbye, World!'",
+			},
+		},
+		{
+			name: "single line command with environment variables",
+			cmd: &Cmd{
+				Script: "echo $GREETING",
+				Environment: map[string]string{
+					"GREETING": "Hello, World!",
+				},
+			},
+			expectedScript:   `sh -c "GREETING='Hello, World!' echo $GREETING"`,
+			expectedContents: nil,
+		},
+		{
+			name: "multiline command with environment variables",
+			cmd: &Cmd{
+				Script: `echo $GREETING
+echo $FAREWELL`,
+				Environment: map[string]string{
+					"GREETING": "Hello, World!",
+					"FAREWELL": "Goodbye, World!",
+				},
+			},
+			expectedScript: "",
+			expectedContents: []string{
+				"#!/bin/sh",
+				"set -e",
+				"export FAREWELL='Goodbye, World!'",
+				"export GREETING='Hello, World!'",
+				"echo $GREETING",
+				"echo $FAREWELL",
+			},
+		},
+		{
+			name: "multiline command with comments",
+			cmd: &Cmd{
+				Script: `# This is a comment
+echo 'Hello, World!' # Inline comment
+# Another comment
+echo 'Goodbye, World!'`,
+			},
+			expectedScript: "",
+			expectedContents: []string{
+				"#!/bin/sh",
+				"set -e",
+				"echo 'Hello, World!'",
+				"echo 'Goodbye, World!'",
+			},
+		},
+		{
+			name: "Empty script",
+			cmd: &Cmd{
+				Script: "",
+			},
+			expectedScript:   "",
+			expectedContents: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			script, reader := tc.cmd.GetScript()
+			assert.Equal(t, tc.expectedScript, script)
+
+			if reader != nil {
+				contents, err := io.ReadAll(reader)
+				assert.NoError(t, err)
+				lines := strings.Split(string(contents), "\n")
+				assert.Equal(t, tc.expectedContents, lines[:len(lines)-1])
+			} else {
+				assert.Nil(t, tc.expectedContents)
+			}
+		})
+	}
+}
+
+func TestCmd_getScriptCommand(t *testing.T) {
 	c, err := New("testdata/f1.yml", nil)
 	require.NoError(t, err)
 	t.Logf("%+v", c)
@@ -78,23 +184,70 @@ func TestCmd_GetScript(t *testing.T) {
 	t.Run("script", func(t *testing.T) {
 		cmd := c.Tasks["deploy-remark42"].Commands[3]
 		assert.Equal(t, "git", cmd.Name, "name")
-		res := cmd.GetScript()
+		res := cmd.getScriptCommand()
 		assert.Equal(t, `sh -c "git clone https://example.com/remark42.git /srv || true; cd /srv; git pull"`, res)
 	})
 
 	t.Run("no-script", func(t *testing.T) {
 		cmd := c.Tasks["deploy-remark42"].Commands[1]
 		assert.Equal(t, "copy configuration", cmd.Name)
-		res := cmd.GetScript()
+		res := cmd.getScriptCommand()
 		assert.Equal(t, "", res)
 	})
 
 	t.Run("script with env", func(t *testing.T) {
 		cmd := c.Tasks["deploy-remark42"].Commands[4]
 		assert.Equal(t, "docker", cmd.Name)
-		res := cmd.GetScript()
-		assert.Equal(t, `sh -c "BAR=qux FOO=bar docker pull umputun/remark42:latest; docker stop remark42 || true; docker rm remark42 || true; docker run -d --name remark42 -p 8080:8080 umputun/remark42:latest"`, res)
+		res := cmd.getScriptCommand()
+		assert.Equal(t, `sh -c "BAR='qux' FOO='bar' docker pull umputun/remark42:latest; docker stop remark42 || true; docker rm remark42 || true; docker run -d --name remark42 -p 8080:8080 umputun/remark42:latest"`, res)
 	})
+}
+
+func TestCmd_getScriptFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      *Cmd
+		expected string
+	}{
+		{
+			name: "no environment variables",
+			cmd: &Cmd{
+				Script: "echo 'Hello, World!'",
+			},
+			expected: "#!/bin/sh\nset -e\necho 'Hello, World!'\n",
+		},
+		{
+			name: "with one environment variable",
+			cmd: &Cmd{
+				Script: "echo 'Hello, World!'",
+				Environment: map[string]string{
+					"VAR1": "value1",
+				},
+			},
+			expected: "#!/bin/sh\nset -e\nexport VAR1='value1'\necho 'Hello, World!'\n",
+		},
+		{
+			name: "with multiple environment variables",
+			cmd: &Cmd{
+				Script: "echo 'Hello, World!'",
+				Environment: map[string]string{
+					"VAR1": "value1",
+					"VAR2": "value2",
+				},
+			},
+			expected: "#!/bin/sh\nset -e\nexport VAR1='value1'\nexport VAR2='value2'\necho 'Hello, World!'\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := tt.cmd.getScriptFile()
+			scriptContentBytes, err := ioutil.ReadAll(reader)
+			assert.NoError(t, err)
+			scriptContent := string(scriptContentBytes)
+			assert.Equal(t, tt.expected, scriptContent)
+		})
+	}
 }
 
 func TestPlayBook_TargetHosts(t *testing.T) {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -55,6 +55,7 @@ func Test_runCompletedAllTasks(t *testing.T) {
 		SSHKey:       "runner/testdata/test_ssh_key",
 		PlaybookFile: "runner/testdata/conf2.yml",
 		TargetName:   hostAndPort,
+		Dbg:          true,
 	}
 	setupLog(true)
 
@@ -63,12 +64,14 @@ func Test_runCompletedAllTasks(t *testing.T) {
 
 	st := time.Now()
 	err := run(opts)
+	t.Log("dbg: ", wr.String())
 	require.NoError(t, err)
 	assert.True(t, time.Since(st) >= 1*time.Second)
 	assert.Contains(t, wr.String(), "task1")
 	assert.Contains(t, wr.String(), "task2")
 	assert.Contains(t, wr.String(), "all good, 123")
 	assert.Contains(t, wr.String(), "good command 2")
+	assert.Contains(t, wr.String(), "all good, 123 - foo-val bar-val")
 
 }
 

--- a/app/runner/runner.go
+++ b/app/runner/runner.go
@@ -304,6 +304,9 @@ func (p *Process) prepScript(ctx context.Context, single string, r io.Reader, ep
 	if err := tmp.Close(); err != nil {
 		return "", nil, fmt.Errorf("can't close temporary file: %w", err)
 	}
+	if err = os.Chmod(tmp.Name(), 0700); err != nil {
+		return "", nil, fmt.Errorf("can't chmod temporary file: %w", err)
+	}
 
 	// get temp file name for remote host
 	dst := filepath.Join("/tmp", filepath.Base(tmp.Name()))
@@ -312,7 +315,7 @@ func (p *Process) prepScript(ctx context.Context, single string, r io.Reader, ep
 	if err := ep.exec.Upload(ctx, tmp.Name(), dst, false); err != nil {
 		return "", nil, fmt.Errorf("can't upload script to %s: %w", ep.host, err)
 	}
-	remoteCmd := fmt.Sprintf("sh -c 'chmod +x %s && %s'", dst, dst)
+	remoteCmd := fmt.Sprintf("sh -c %s", dst)
 
 	teardown := func() error {
 		// remove the script from the remote host, called by the caller

--- a/app/runner/runner.go
+++ b/app/runner/runner.go
@@ -304,6 +304,8 @@ func (p *Process) prepScript(ctx context.Context, single string, r io.Reader, ep
 	if err = tmp.Close(); err != nil {
 		return "", nil, fmt.Errorf("can't close temporary file: %w", err)
 	}
+
+	// make the script executable locally, upload preserves the permissions
 	if err = os.Chmod(tmp.Name(), 0o700); err != nil { //nolint
 		return "", nil, fmt.Errorf("can't chmod temporary file: %w", err)
 	}
@@ -318,7 +320,7 @@ func (p *Process) prepScript(ctx context.Context, single string, r io.Reader, ep
 	remoteCmd := fmt.Sprintf("sh -c %s", dst)
 
 	teardown := func() error {
-		// remove the script from the remote host, called by the caller
+		// remove the script from the remote host, should be invoked by the caller after the command is executed
 		if err := ep.exec.Delete(ctx, dst, false); err != nil {
 			return fmt.Errorf("can't remove temporary remote script %s (%s): %w", dst, ep.host, err)
 		}

--- a/app/runner/testdata/conf2.yml
+++ b/app/runner/testdata/conf2.yml
@@ -15,8 +15,12 @@ tasks:
         script: |
           ls -laR /tmp
           du -hcs /srv
+          echo "blah" > /tmp/conf.yml
           cat /tmp/conf.yml
-          echo all good, 123
+          echo "all good, 123 - $FOO $BAR"
+        env:
+          FOO: foo-val
+          BAR: bar-val
       - name: show content
         script: ls -laR /tmp
 


### PR DESCRIPTION
This PR treats any multiline `script` as a shell file, i.e. it makes a temp sh file, upload it to the remote host and executes. After execution completed (or failed) that temp script get removed