### PR TITLE
Verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ SimploTask supports the following command-line options:
 - `-s`, `--skip=`: Skips the specified commands during the task execution. Providing the `-s` flag multiple times with different command names skips multiple commands.
 - `-o`, `--only=`: Runs only the specified commands during the task execution. Providing the `-o` flag multiple times with different command names runs only multiple commands.
 - `-e`, `--env=`: Sets the environment variables to be used during the task execution. Providing the `-e` flag multiple times with different environment variables sets multiple environment variables, e.g., `-e VAR1=VALUE1 -e VAR2=VALUE2`.
-- `--dbg`: Enables debug mode, providing more detailed output and error messages during the task execution.
+- `-v`, `--verbose`: Enables verbose mode, providing more detailed output and error messages during the task execution.
+- `--dbg`: Enables debug mode, providing even more detailed output and error messages during the task execution as well as diagnostic messages.
 - `-h`, `--help`: Displays the help message, listing all available command-line options.
 
 ## Example playbook

--- a/app/executor/executor.go
+++ b/app/executor/executor.go
@@ -3,15 +3,22 @@
 package executor
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"fmt"
+	"hash/crc32"
+	"io"
 	"log"
 	"strings"
+
+	"github.com/fatih/color"
 )
 
 // Interface is an interface for the executor.
 // Implemented by Remote and Local structs.
 type Interface interface {
-	Run(ctx context.Context, c string) (out []string, err error)
+	Run(ctx context.Context, c string, verbose bool) (out []string, err error)
 	Upload(ctx context.Context, local, remote string, mkdir bool) (err error)
 	Download(ctx context.Context, remote, local string, mkdir bool) (err error)
 	Sync(ctx context.Context, localDir, remoteDir string, del bool) ([]string, error)
@@ -25,8 +32,8 @@ type StdOutLogWriter struct {
 	level  string
 }
 
-// NewStdOutLogWriter creates a new StdOutLogWriter.
-func NewStdOutLogWriter(prefix, level string) *StdOutLogWriter {
+// NewStdoutLogWriter creates a new StdOutLogWriter.
+func NewStdoutLogWriter(prefix, level string) *StdOutLogWriter {
 	return &StdOutLogWriter{prefix: prefix, level: level}
 }
 
@@ -39,4 +46,57 @@ func (w *StdOutLogWriter) Write(p []byte) (n int, err error) {
 		log.Printf("[%s] %s %s", w.level, w.prefix, line)
 	}
 	return len(p), nil
+}
+
+// ColorizedWriter is a writer that colorizes the output based on the host name.
+type ColorizedWriter struct {
+	wr     io.Writer
+	prefix string
+	host   string
+}
+
+// NewColorizedWriter creates a new ColorizedWriter with the given host name.
+func NewColorizedWriter(wr io.Writer, prefix, host string) *ColorizedWriter {
+	return &ColorizedWriter{wr: wr, host: host, prefix: prefix}
+}
+
+// WithHost creates a new StdoutColorWriter with the given host name.
+func (s *ColorizedWriter) WithHost(host string) *ColorizedWriter {
+	return &ColorizedWriter{wr: s.wr, host: host, prefix: s.prefix}
+}
+
+// Write writes the given byte slice to stdout with the colorized host prefix for each line.
+// If the input does not end with a newline, one is added.
+func (s *ColorizedWriter) Write(p []byte) (n int, err error) {
+	scanner := bufio.NewScanner(bytes.NewReader(p))
+	for scanner.Scan() {
+		line := scanner.Text()
+		formattedOutput := fmt.Sprintf("[%s] %s %s", s.host, s.prefix, line)
+		if s.prefix == "" {
+			formattedOutput = fmt.Sprintf("[%s] %s", s.host, line)
+		}
+		colorizer := hostColorizer(s.host)
+		colorizedOutput := colorizer("%s\n", formattedOutput)
+		_, err = io.WriteString(s.wr, colorizedOutput)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// hostColorizer returns a function that formats a string with a color based on the host name.
+func hostColorizer(host string) func(format string, a ...interface{}) string {
+	colors := []color.Attribute{
+		color.FgHiRed, color.FgHiGreen, color.FgHiYellow,
+		color.FgHiBlue, color.FgHiMagenta, color.FgHiCyan,
+		color.FgCyan, color.FgMagenta, color.FgBlue,
+		color.FgYellow, color.FgGreen, color.FgRed,
+	}
+	i := crc32.ChecksumIEEE([]byte(host)) % uint32(len(colors))
+	return color.New(colors[i]).SprintfFunc()
 }

--- a/app/executor/executor_test.go
+++ b/app/executor/executor_test.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"log"
 	"strings"
 	"testing"
@@ -114,8 +113,8 @@ func TestColorizedWriter(t *testing.T) {
 			host:   "localhost",
 			input:  "This is a test message\nThis is another test message",
 			expectedLines: []string{
-				fmt.Sprintf("[localhost] INFO This is a test message"),
-				fmt.Sprintf("[localhost] INFO This is another test message"),
+				"[localhost] INFO This is a test message",
+				"[localhost] INFO This is another test message",
 			},
 		},
 		{
@@ -124,8 +123,8 @@ func TestColorizedWriter(t *testing.T) {
 			host:   "localhost",
 			input:  "This is a test message\nThis is another test message",
 			expectedLines: []string{
-				fmt.Sprintf("[localhost] This is a test message"),
-				fmt.Sprintf("[localhost] This is another test message"),
+				"[localhost] This is a test message",
+				"[localhost] This is another test message",
 			},
 		},
 	}

--- a/app/executor/local.go
+++ b/app/executor/local.go
@@ -18,11 +18,11 @@ import (
 type Local struct{}
 
 // Run executes command on local host, inside the shell
-func (l *Local) Run(ctx context.Context, cmd string) (out []string, err error) {
+func (l *Local) Run(ctx context.Context, cmd string, verbose bool) (out []string, err error) {
 	command := exec.CommandContext(ctx, "sh", "-c", cmd)
 	var stdoutBuf bytes.Buffer
-	mwr := io.MultiWriter(NewStdOutLogWriter(">", "DEBUG"), &stdoutBuf)
-	command.Stdout, command.Stderr = mwr, NewStdOutLogWriter("!", "WARN")
+	mwr := io.MultiWriter(NewStdoutLogWriter(">", "DEBUG"), &stdoutBuf)
+	command.Stdout, command.Stderr = mwr, NewStdoutLogWriter("!", "WARN")
 	err = command.Run()
 	if err != nil {
 		return nil, err
@@ -168,6 +168,14 @@ func (l *Local) copyFile(src, dst string) error {
 	}
 
 	if err := dstFile.Sync(); err != nil {
+		return err
+	}
+
+	fi, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+	if err := os.Chmod(dst, fi.Mode()); err != nil {
 		return err
 	}
 

--- a/app/executor/local_test.go
+++ b/app/executor/local_test.go
@@ -31,15 +31,27 @@ func TestRun(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			l := &Local{}
-			out, err := l.Run(context.Background(), tc.cmd, false)
-
-			if tc.expectError {
-				assert.Error(t, err, "expected an error")
-				return
+			{
+				out, err := l.Run(context.Background(), tc.cmd, false)
+				if tc.expectError {
+					assert.Error(t, err, "expected an error")
+					return
+				}
+				assert.NoError(t, err, "unexpected error")
+				require.Equal(t, 1, len(out), "output should have exactly one line")
+				assert.Equal(t, "Hello, World!", out[0], "output line should match expected value")
 			}
-			assert.NoError(t, err, "unexpected error")
-			require.Equal(t, 1, len(out), "output should have exactly one line")
-			assert.Equal(t, "Hello, World!", out[0], "output line should match expected value")
+			{
+				out, err := l.Run(context.Background(), tc.cmd, true)
+				if tc.expectError {
+					assert.Error(t, err, "expected an error")
+					return
+				}
+				assert.NoError(t, err, "unexpected error")
+				require.Equal(t, 1, len(out), "output should have exactly one line")
+				assert.Equal(t, "Hello, World!", out[0], "output line should match expected value")
+			}
+
 		})
 	}
 }

--- a/app/executor/local_test.go
+++ b/app/executor/local_test.go
@@ -31,7 +31,7 @@ func TestRun(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			l := &Local{}
-			out, err := l.Run(context.Background(), tc.cmd)
+			out, err := l.Run(context.Background(), tc.cmd, false)
 
 			if tc.expectError {
 				assert.Error(t, err, "expected an error")

--- a/app/executor/remote.go
+++ b/app/executor/remote.go
@@ -206,7 +206,7 @@ func (ex *Remote) sshRun(ctx context.Context, client *ssh.Client, command string
 		outLog = NewStdoutLogWriter(">", "DEBUG")
 		errLog = NewStdoutLogWriter("!", "WARN")
 	}
-	outLog.Write([]byte(command))
+	outLog.Write([]byte(command)) //nolint
 
 	var stdoutBuf bytes.Buffer
 	mwr := io.MultiWriter(outLog, &stdoutBuf)

--- a/app/executor/remote_test.go
+++ b/app/executor/remote_test.go
@@ -135,7 +135,7 @@ func TestExecuter_Run(t *testing.T) {
 	defer sess.Close()
 
 	t.Run("single line out", func(t *testing.T) {
-		out, e := sess.Run(ctx, "sh -c 'echo hello world'")
+		out, e := sess.Run(ctx, "sh -c 'echo hello world'", false)
 		require.NoError(t, e)
 		assert.Equal(t, []string{"hello world"}, out)
 	})
@@ -146,7 +146,7 @@ func TestExecuter_Run(t *testing.T) {
 		err = sess.Upload(ctx, "testdata/data.txt", "/tmp/st/data2.txt", true)
 		assert.NoError(t, err)
 
-		out, err := sess.Run(ctx, "ls -1 /tmp/st")
+		out, err := sess.Run(ctx, "ls -1 /tmp/st", false)
 		require.NoError(t, err)
 		t.Logf("out: %v", out)
 		assert.Equal(t, 2, len(out))
@@ -156,7 +156,7 @@ func TestExecuter_Run(t *testing.T) {
 
 	t.Run("find out", func(t *testing.T) {
 		cmd := fmt.Sprintf("find %s -type f -exec stat -c '%%n:%%s' {} \\;", "/tmp/")
-		out, e := sess.Run(ctx, cmd)
+		out, e := sess.Run(ctx, cmd, true)
 		require.NoError(t, e)
 		sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
 		assert.Equal(t, []string{"/tmp/st/data1.txt:68", "/tmp/st/data2.txt:68"}, out)
@@ -180,7 +180,7 @@ func TestExecuter_Sync(t *testing.T) {
 		require.NoError(t, e)
 		sort.Slice(res, func(i, j int) bool { return res[i] < res[j] })
 		assert.Equal(t, []string{"d1/file11.txt", "file1.txt", "file2.txt"}, res)
-		out, e := sess.Run(ctx, "find /tmp/sync.dest -type f -exec stat -c '%s %n' {} \\;")
+		out, e := sess.Run(ctx, "find /tmp/sync.dest -type f -exec stat -c '%s %n' {} \\;", true)
 		require.NoError(t, e)
 		sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
 		assert.Equal(t, []string{"17 /tmp/sync.dest/d1/file11.txt", "185 /tmp/sync.dest/file1.txt", "61 /tmp/sync.dest/file2.txt"}, out)
@@ -218,7 +218,7 @@ func TestExecuter_Delete(t *testing.T) {
 	t.Run("delete file", func(t *testing.T) {
 		err = sess.Delete(ctx, "/tmp/sync.dest/file1.txt", false)
 		assert.NoError(t, err)
-		out, e := sess.Run(ctx, "ls -1 /tmp/sync.dest")
+		out, e := sess.Run(ctx, "ls -1 /tmp/sync.dest", false)
 		require.NoError(t, e)
 		assert.Equal(t, []string{"d1", "file2.txt"}, out)
 	})
@@ -226,7 +226,7 @@ func TestExecuter_Delete(t *testing.T) {
 	t.Run("delete dir", func(t *testing.T) {
 		err = sess.Delete(ctx, "/tmp/sync.dest", true)
 		assert.NoError(t, err)
-		out, e := sess.Run(ctx, "ls -1 /tmp/")
+		out, e := sess.Run(ctx, "ls -1 /tmp/", true)
 		require.NoError(t, e)
 		assert.NotContains(t, out, "file2.txt", out)
 	})

--- a/app/main.go
+++ b/app/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"log"
 	"os"
@@ -100,7 +99,8 @@ func run(opts options) error {
 		Config:      conf,
 		Only:        opts.Only,
 		Skip:        opts.Skip,
-		Colorizer:   hostColorizer,
+		ColorWriter: executor.NewColorizedWriter(os.Stdout, "", ""),
+		Verbose:     opts.Verbose,
 	}
 
 	if opts.TaskName != "" { // run single task
@@ -153,15 +153,6 @@ func sshUserAndKey(opts options, conf *config.PlayBook) (uname, key string) {
 	}
 
 	return sshUser, sshKey
-}
-
-// hostColorizer returns a function that formats a string with a color based on the host name.
-func hostColorizer(host string) func(format string, a ...interface{}) string {
-	colors := []color.Attribute{color.FgHiRed, color.FgHiGreen, color.FgHiYellow,
-		color.FgHiBlue, color.FgHiMagenta, color.FgHiCyan, color.FgCyan, color.FgMagenta,
-		color.FgBlue, color.FgYellow, color.FgGreen, color.FgRed}
-	i := crc32.ChecksumIEEE([]byte(host)) % uint32(len(colors))
-	return color.New(colors[i]).SprintfFunc()
 }
 
 func setupLog(dbg bool) {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -7,12 +7,9 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"regexp"
-	"strconv"
 	"testing"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -181,64 +178,6 @@ func Test_sshUserAndKey(t *testing.T) {
 	}
 }
 
-func TestHostColorizer(t *testing.T) {
-	getColorAttributeFromFormattedString := func(s string) (color.Attribute, error) {
-		colorCodeRegExp := regexp.MustCompile(`\x1b\[(\d+)m`)
-		matches := colorCodeRegExp.FindStringSubmatch(s)
-		if len(matches) == 2 {
-			colorCode, err := strconv.Atoi(matches[1])
-			if err != nil {
-				return 0, err
-			}
-			return color.Attribute(colorCode), nil
-		}
-		return 0, fmt.Errorf("no color code found in string")
-	}
-
-	hostColorizerTestCases := []struct {
-		name string
-		host string
-	}{
-		{
-			name: "Case 1",
-			host: "example1.com",
-		},
-		{
-			name: "Case 2",
-			host: "example2.com",
-		},
-		{
-			name: "Case 3",
-			host: "example3.com",
-		},
-		// Add more test cases here
-	}
-
-	for _, tc := range hostColorizerTestCases {
-		t.Run(tc.name, func(t *testing.T) {
-			colorizer := hostColorizer(tc.host)
-
-			// Test the colorizer function with a sample string
-			testString := "Test string"
-			colorizedString := colorizer(testString)
-
-			// Check if the output string is different from the input string
-			assert.NotEqual(t, testString, colorizedString, "Colorized output should be different from the input string")
-
-			// Get color attribute from the colorized string
-			colorAttr, err := getColorAttributeFromFormattedString(colorizedString)
-			assert.NoError(t, err, "Error should be nil when extracting color attribute")
-
-			// Check if the same host produces the same color
-			for i := 0; i < 5; i++ {
-				colorizedStringRepeated := colorizer(testString)
-				colorAttrRepeated, err := getColorAttributeFromFormattedString(colorizedStringRepeated)
-				assert.NoError(t, err, "Error should be nil when extracting color attribute")
-				assert.Equal(t, colorAttr, colorAttrRepeated, "Color attribute should remain the same for the same host")
-			}
-		})
-	}
-}
 func startTestContainer(t *testing.T) (hostAndPort string, teardown func()) {
 	t.Helper()
 	ctx := context.Background()

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -99,6 +99,22 @@ func Test_runCanceled(t *testing.T) {
 	signal.NotifyContext(ctx, os.Interrupt)
 }
 
+func Test_runFailed(t *testing.T) {
+	hostAndPort, teardown := startTestContainer(t)
+	defer teardown()
+
+	opts := options{
+		SSHUser:      "test",
+		SSHKey:       "runner/testdata/test_ssh_key",
+		PlaybookFile: "runner/testdata/conf-local-failed.yml",
+		TaskName:     "default",
+		TargetName:   hostAndPort,
+	}
+	setupLog(true)
+	err := run(opts)
+	assert.ErrorContains(t, err, `can't run command "show content"`)
+}
+
 func Test_sshUserAndKey(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -7,9 +7,12 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -178,6 +181,64 @@ func Test_sshUserAndKey(t *testing.T) {
 	}
 }
 
+func TestHostColorizer(t *testing.T) {
+	getColorAttributeFromFormattedString := func(s string) (color.Attribute, error) {
+		colorCodeRegExp := regexp.MustCompile(`\x1b\[(\d+)m`)
+		matches := colorCodeRegExp.FindStringSubmatch(s)
+		if len(matches) == 2 {
+			colorCode, err := strconv.Atoi(matches[1])
+			if err != nil {
+				return 0, err
+			}
+			return color.Attribute(colorCode), nil
+		}
+		return 0, fmt.Errorf("no color code found in string")
+	}
+
+	hostColorizerTestCases := []struct {
+		name string
+		host string
+	}{
+		{
+			name: "Case 1",
+			host: "example1.com",
+		},
+		{
+			name: "Case 2",
+			host: "example2.com",
+		},
+		{
+			name: "Case 3",
+			host: "example3.com",
+		},
+		// Add more test cases here
+	}
+
+	for _, tc := range hostColorizerTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			colorizer := hostColorizer(tc.host)
+
+			// Test the colorizer function with a sample string
+			testString := "Test string"
+			colorizedString := colorizer(testString)
+
+			// Check if the output string is different from the input string
+			assert.NotEqual(t, testString, colorizedString, "Colorized output should be different from the input string")
+
+			// Get color attribute from the colorized string
+			colorAttr, err := getColorAttributeFromFormattedString(colorizedString)
+			assert.NoError(t, err, "Error should be nil when extracting color attribute")
+
+			// Check if the same host produces the same color
+			for i := 0; i < 5; i++ {
+				colorizedStringRepeated := colorizer(testString)
+				colorAttrRepeated, err := getColorAttributeFromFormattedString(colorizedStringRepeated)
+				assert.NoError(t, err, "Error should be nil when extracting color attribute")
+				assert.Equal(t, colorAttr, colorAttrRepeated, "Color attribute should remain the same for the same host")
+			}
+		})
+	}
+}
 func startTestContainer(t *testing.T) (hostAndPort string, teardown func()) {
 	t.Helper()
 	ctx := context.Background()

--- a/app/runner/runner.go
+++ b/app/runner/runner.go
@@ -112,9 +112,7 @@ func (p *Process) runTaskOnHost(ctx context.Context, tsk *config.Task, host stri
 	}
 	defer remote.Close()
 
-	wr := p.ColorWriter.WithHost(host)
-	fmt.Fprintf(wr, "run task %s, commands: %d\n", tsk.Name, len(tsk.Commands))
-
+	fmt.Fprintf(p.ColorWriter.WithHost(host), "run task %s, commands: %d\n", tsk.Name, len(tsk.Commands))
 	count := 0
 	for _, cmd := range tsk.Commands {
 		if len(p.Only) > 0 && !contains(p.Only, cmd.Name) {
@@ -141,17 +139,15 @@ func (p *Process) runTaskOnHost(ctx context.Context, tsk *config.Task, host stri
 				return count, fmt.Errorf("can't run command %q on host %s: %w", cmd.Name, host, err)
 			}
 
-			wr := p.ColorWriter.WithHost(host)
-			fmt.Fprintf(wr, "failed %s%s (%v)", cmd.Name, details, time.Since(st).Truncate(time.Millisecond))
+			fmt.Fprintf(p.ColorWriter.WithHost(host), "failed %s%s (%v)", cmd.Name, details, time.Since(st).Truncate(time.Millisecond))
 			continue
 		}
 
-		fmt.Fprintf(wr, "completed %s%s (%v)", cmd.Name, details, time.Since(st).Truncate(time.Millisecond))
+		fmt.Fprintf(p.ColorWriter.WithHost(host), "completed %s%s (%v)", cmd.Name, details, time.Since(st).Truncate(time.Millisecond))
 		count++
 	}
 
-	wr = p.ColorWriter.WithHost(host)
-	fmt.Fprintf(wr, "completed task %s, commands: %d\n", tsk.Name, count)
+	fmt.Fprintf(p.ColorWriter.WithHost(host), "completed task %s, commands: %d\n", tsk.Name, count)
 
 	return count, nil
 }

--- a/app/runner/testdata/conf-local-failed.yml
+++ b/app/runner/testdata/conf-local-failed.yml
@@ -1,0 +1,13 @@
+tasks:
+  default:
+    commands:
+      - name: some command
+        script: |
+          echo "something"  > /tmp/something
+          cat /tmp/something
+          echo all good, 123
+        options: {local: true}
+
+      - name: show content
+        script: ls /tmp/not-found
+        options: {local: true}


### PR DESCRIPTION
add support of `-v` / `--verbose`. In this mode, `spot` will output the command executed on remote/local as well as stdout/stderr