### PR TITLE
Using spot.yml & SPOT_FILE in code

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 type options struct {
-	PlaybookFile string `short:"f" long:"file" env:"SPT_FILE" description:"playbook file" default:"spt.yml"`
+	PlaybookFile string `short:"f" long:"file" env:"SPOT_FILE" description:"playbook file" default:"spot.yml"`
 	TaskName     string `short:"t" long:"task" description:"task name"`
 	TargetName   string `short:"d" long:"target" description:"target name" default:"default"`
 	Concurrent   int    `short:"c" long:"concurrent" description:"concurrent tasks" default:"1"`


### PR DESCRIPTION
In docs there is stated:

 * `Defaults to spot.yml`
 * `You can also set the environment variable $SPOT_FILE` 
 
 ( https://github.com/umputun/simplotask/blob/7db4a2cff0c8b00101997f1ae3fcdc9d4539d604/README.md?plain=1#LL43C60-L43C82 ) 
 
 But it is not true in the code. This pull request corrects the code to aligned with the documentation.

