### PR TITLE
Inventory groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ targets:
   prod:
     hosts: ["h1.example.com", "h2.example.com"]
   staging:
-    inventory_file: "testdata/inventory"
+    inventory_file: {location: "testdata/inventory", group: "staging"}
   dev:
-    inventory_url: "http://localhost:8080/inventory"
+    inventory_url: {location: "http://localhost:8080/inventory", group: "dev"}
+  dev_and_staging:
+    inventory_file: {location: "testdata/inventory", group: all}
 
 # list of tasks, i.e. commands to execute
 tasks:
@@ -208,22 +210,43 @@ By using this approach, SimploTask enables users to write and execute more compl
 
 Targets are used to define the remote hosts to execute the tasks on. Targets can be defined in the playbook file or passed as a command-line argument. The following target types are supported:
 
-- `hosts`: a list of host names or IP addresses to execute the tasks on. Example: `hosts: ["h1.example.com", "h2.example.com"]`
-- `inventory_file`: a path to the inventory file to use. Example: `inventory_file: "testdata/inventory"`. The file contains a list of host names or IP addresses, one per line.
-- `inventory_url`: a URL to the inventory file to use. Example: `inventory_url: "http://localhost:8080/inventory"`. The response contains a list of host names or IP addresses, one per line.
-
-_note: if host has no port specified, port 22 will be used._
+- `hosts`: a list of destination host names or IP addresses, with optional port and username, to execute the tasks on. Example: `hosts: [{host: "h1.example.com", user: test}, {host: "h2.example.com", "port": 2222}]`. If no user is specified, the user defined in the top section of the playbook file (or override)  will be used. If no port is specified, port 22 will be used.
+- `inventory_file`: a path to the inventory file to use and group to use. Example: `inventory_file: {"location": "testdata/inventory", "group": "gr1"}`. If `group` not defined or set to `all` all the groups will be used.  The file contains a list of host names or IP addresses, one per line with options `[group]` values.
+- `inventory_url`: a URL to the inventory file to use. Example: `inventory_url: {"location": "http://localhost:8080/inventory"}`. The response contains a list of host names or IP addresses, one per line. The same support for groups as for `inventory_file` is available.
 
 Targets contains environments each of which represents a set of hosts, for example:
 
 ```yaml
 targets:
   prod:
-    hosts: ["h1.example.com", "h2.example.com"]
+    hosts: [{host: "h1.example.com", user: "test"}, {"h2.example.com", "port": 2222}]
   staging:
-    inventory_file: "testdata/inventory"
+    inventory_file: {location: "testdata/inventory", group: "staging"}
   dev:
-    inventory_url: "http://localhost:8080/inventory"
+    inventory_url: {location: "http://localhost:8080/inventory"}
+```
+
+### Inventory file format
+
+The inventory file is a simple text file with a list of host names or IP addresses, one per line. The file can contain groups, each group is defined by a line with the group name in square brackets `[group]` followed by a list of hosts that belong to the group. For example:
+
+```text
+[group1]
+h1.example.com
+h2.example.com:2222
+h3.example.com user1
+
+[group2]
+h4.example.com:2222 user2
+```
+
+In case if groups not needed, the file can contain only a list of hosts, for example:
+
+```text
+h1.example.com
+h2.example.com:2222
+h3.example.com user1
+h4.example.com:2222 user2
 ```
 
 ## Runtime variables

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ targets:
   prod:
     hosts: ["h1.example.com", "h2.example.com"]
   staging:
-    inventory_file: {location: "testdata/inventory", group: "staging"}
+    inventory_file: {location: "testdata/inventory", groups: ["staging"]}
   dev:
-    inventory_url: {location: "http://localhost:8080/inventory", group: "dev"}
+    inventory_url: {location: "http://localhost:8080/inventory", groups: ["dev"]}
   dev_and_staging:
-    inventory_file: {location: "testdata/inventory", group: all}
+    inventory_file: {location: "testdata/inventory"}
 
 # list of tasks, i.e. commands to execute
 tasks:
@@ -211,7 +211,7 @@ By using this approach, SimploTask enables users to write and execute more compl
 Targets are used to define the remote hosts to execute the tasks on. Targets can be defined in the playbook file or passed as a command-line argument. The following target types are supported:
 
 - `hosts`: a list of destination host names or IP addresses, with optional port and username, to execute the tasks on. Example: `hosts: [{host: "h1.example.com", user: test}, {host: "h2.example.com", "port": 2222}]`. If no user is specified, the user defined in the top section of the playbook file (or override)  will be used. If no port is specified, port 22 will be used.
-- `inventory_file`: a path to the inventory file to use and group to use. Example: `inventory_file: {"location": "testdata/inventory", "group": "gr1"}`. If `group` not defined or set to `all` all the groups will be used.  The file contains a list of host names or IP addresses, one per line with options `[group]` values.
+- `inventory_file`: a path to the inventory file to use and groups to use. Example: `inventory_file: {"location": "testdata/inventory", "groups": []{"gr1"} }`. If `groups` not defined all the groups will be used. The [inventory file](#inventory-file-format) contains a list of host names or IP addresses, one per line with optional `[group]` values.
 - `inventory_url`: a URL to the inventory file to use. Example: `inventory_url: {"location": "http://localhost:8080/inventory"}`. The response contains a list of host names or IP addresses, one per line. The same support for groups as for `inventory_file` is available.
 
 Targets contains environments each of which represents a set of hosts, for example:
@@ -221,9 +221,9 @@ targets:
   prod:
     hosts: [{host: "h1.example.com", user: "test"}, {"h2.example.com", "port": 2222}]
   staging:
-    inventory_file: {location: "testdata/inventory", group: "staging"}
+    inventory_file: {location: "testdata/inventory", groups: ["staging"]}
   dev:
-    inventory_url: {location: "http://localhost:8080/inventory"}
+    inventory_url: {location: "http://localhost:8080/inventory", groups: ["dev", "staging"]}
 ```
 
 ### Inventory file format

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -260,7 +260,7 @@ func TestPlaybook_TargetHosts(t *testing.T) {
 				},
 			},
 			"target2": {
-				InventoryFile: "testdata/hosts",
+				InventoryFile: Inventory{Location: "testdata/hosts", Group: "gr1"},
 			},
 			"target3": {},
 		},
@@ -412,7 +412,7 @@ func TestPlayBook_TargetHostsOverrides(t *testing.T) {
 	t.Run("override hosts directly", func(t *testing.T) {
 		c, err := New("testdata/f1.yml", &Overrides{TargetHosts: []string{"h1", "h2"}})
 		require.NoError(t, err)
-		res, err := c.TargetHosts("blah")
+		res, err := c.TargetHosts("blah") // no such target
 		require.NoError(t, err)
 		assert.Equal(t, []Destination{{Host: "h1", Port: 22, User: "umputun"}, {Host: "h2", Port: 22, User: "umputun"}}, res)
 	})
@@ -427,6 +427,8 @@ func TestPlayBook_TargetHostsOverrides(t *testing.T) {
 			{Host: "h2.example.com", Port: 2233, User: "umputun"},
 			{Host: "h3.example.com", Port: 22, User: "user1"},
 			{Host: "h4.example.com", Port: 2233, User: "user2"},
+			{Host: "h5.example.com", Port: 2233, User: "umputun"},
+			{Host: "h6.example.com", Port: 22, User: "user3"},
 		}, res)
 	})
 
@@ -467,4 +469,116 @@ func TestPlayBook_TargetHostsOverrides(t *testing.T) {
 		require.ErrorContains(t, err, "status: 500 Internal Server Error")
 		t.Log(err)
 	})
+}
+
+func TestPlayBook_parseInventory(t *testing.T) {
+	inventoryContent := `[gr1]
+hh1.example.com
+#blah blah blah
+h2.example.com:2233
+h3.example.com user1
+h4.example.com:2233 user2
+
+[gr2]
+h5.example.com:2233
+h6.example.com user3
+`
+	playbook := &PlayBook{User: "defaultUser"}
+
+	tests := []struct {
+		name         string
+		groupName    string
+		want         []Destination
+		removeGroups bool
+	}{
+		{
+			name:      "All groups",
+			groupName: "all",
+			want: []Destination{
+				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
+				{Host: "h2.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h3.example.com", Port: 22, User: "user1"},
+				{Host: "h4.example.com", Port: 2233, User: "user2"},
+				{Host: "h5.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h6.example.com", Port: 22, User: "user3"},
+			},
+		},
+		{
+			name:      "Group 1",
+			groupName: "gr1",
+			want: []Destination{
+				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
+				{Host: "h2.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h3.example.com", Port: 22, User: "user1"},
+				{Host: "h4.example.com", Port: 2233, User: "user2"},
+			},
+		},
+		{
+			name:      "Group 2",
+			groupName: "gr2",
+			want: []Destination{
+				{Host: "h5.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h6.example.com", Port: 22, User: "user3"},
+			},
+		},
+		{
+			name:      "Empty group name",
+			groupName: "",
+			want: []Destination{
+				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
+				{Host: "h2.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h3.example.com", Port: 22, User: "user1"},
+				{Host: "h4.example.com", Port: 2233, User: "user2"},
+				{Host: "h5.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h6.example.com", Port: 22, User: "user3"},
+			},
+		},
+		{
+			name:         "No-group inventory",
+			groupName:    "",
+			removeGroups: true,
+			want: []Destination{
+				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
+				{Host: "h2.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h3.example.com", Port: 22, User: "user1"},
+				{Host: "h4.example.com", Port: 2233, User: "user2"},
+				{Host: "h5.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h6.example.com", Port: 22, User: "user3"},
+			},
+		},
+		{
+			name:         "No-group inventory but name is set to all",
+			groupName:    "all",
+			removeGroups: true,
+			want: []Destination{
+				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
+				{Host: "h2.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h3.example.com", Port: 22, User: "user1"},
+				{Host: "h4.example.com", Port: 2233, User: "user2"},
+				{Host: "h5.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h6.example.com", Port: 22, User: "user3"},
+			},
+		},
+		{
+			name:      "Non-existent group",
+			groupName: "non-existent",
+			want:      []Destination{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reader io.Reader
+			if tt.removeGroups {
+				inventoryContent := strings.ReplaceAll(inventoryContent, "[gr1]", "")
+				inventoryContent = strings.ReplaceAll(inventoryContent, "[gr2]", "")
+				reader = strings.NewReader(inventoryContent)
+			} else {
+				reader = strings.NewReader(inventoryContent)
+			}
+			got, err := playbook.parseInventory(reader, tt.groupName)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -260,7 +260,7 @@ func TestPlaybook_TargetHosts(t *testing.T) {
 				},
 			},
 			"target2": {
-				InventoryFile: Inventory{Location: "testdata/hosts", Group: "gr1"},
+				InventoryFile: Inventory{Location: "testdata/hosts", Groups: []string{"gr1"}},
 			},
 			"target3": {},
 		},
@@ -487,13 +487,13 @@ h6.example.com user3
 
 	tests := []struct {
 		name         string
-		groupName    string
+		grpups       []string
 		want         []Destination
 		removeGroups bool
 	}{
 		{
-			name:      "All groups",
-			groupName: "all",
+			name:   "All groups",
+			grpups: nil,
 			want: []Destination{
 				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
 				{Host: "h2.example.com", Port: 2233, User: "defaultUser"},
@@ -504,8 +504,8 @@ h6.example.com user3
 			},
 		},
 		{
-			name:      "Group 1",
-			groupName: "gr1",
+			name:   "Group 1",
+			grpups: []string{"gr1"},
 			want: []Destination{
 				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
 				{Host: "h2.example.com", Port: 2233, User: "defaultUser"},
@@ -514,16 +514,28 @@ h6.example.com user3
 			},
 		},
 		{
-			name:      "Group 2",
-			groupName: "gr2",
+			name:   "Group 2",
+			grpups: []string{"gr2"},
 			want: []Destination{
 				{Host: "h5.example.com", Port: 2233, User: "defaultUser"},
 				{Host: "h6.example.com", Port: 22, User: "user3"},
 			},
 		},
 		{
-			name:      "Empty group name",
-			groupName: "",
+			name:   "Group 1 and 2",
+			grpups: []string{"gr1", "gr2"},
+			want: []Destination{
+				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
+				{Host: "h2.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h3.example.com", Port: 22, User: "user1"},
+				{Host: "h4.example.com", Port: 2233, User: "user2"},
+				{Host: "h5.example.com", Port: 2233, User: "defaultUser"},
+				{Host: "h6.example.com", Port: 22, User: "user3"},
+			},
+		},
+		{
+			name:   "Empty groups",
+			grpups: []string{},
 			want: []Destination{
 				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
 				{Host: "h2.example.com", Port: 2233, User: "defaultUser"},
@@ -535,7 +547,6 @@ h6.example.com user3
 		},
 		{
 			name:         "No-group inventory",
-			groupName:    "",
 			removeGroups: true,
 			want: []Destination{
 				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
@@ -548,7 +559,7 @@ h6.example.com user3
 		},
 		{
 			name:         "No-group inventory but name is set to all",
-			groupName:    "all",
+			grpups:       []string{"all"},
 			removeGroups: true,
 			want: []Destination{
 				{Host: "hh1.example.com", Port: 22, User: "defaultUser"},
@@ -560,9 +571,9 @@ h6.example.com user3
 			},
 		},
 		{
-			name:      "Non-existent group",
-			groupName: "non-existent",
-			want:      []Destination{},
+			name:   "Non-existent group",
+			grpups: []string{"non-existent"},
+			want:   []Destination{},
 		},
 	}
 
@@ -576,7 +587,7 @@ h6.example.com user3
 			} else {
 				reader = strings.NewReader(inventoryContent)
 			}
-			got, err := playbook.parseInventory(reader, tt.groupName)
+			got, err := playbook.parseInventory(reader, tt.grpups)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -570,9 +570,9 @@ h6.example.com user3
 		t.Run(tt.name, func(t *testing.T) {
 			var reader io.Reader
 			if tt.removeGroups {
-				inventoryContent := strings.ReplaceAll(inventoryContent, "[gr1]", "")
-				inventoryContent = strings.ReplaceAll(inventoryContent, "[gr2]", "")
-				reader = strings.NewReader(inventoryContent)
+				inventoryContentCleaned := strings.ReplaceAll(inventoryContent, "[gr1]", "")
+				inventoryContentCleaned = strings.ReplaceAll(inventoryContentCleaned, "[gr2]", "")
+				reader = strings.NewReader(inventoryContentCleaned)
 			} else {
 				reader = strings.NewReader(inventoryContent)
 			}

--- a/app/config/testdata/bad-format.yml
+++ b/app/config/testdata/bad-format.yml
@@ -1,9 +1,9 @@
-- user: umputun
+-user: umputun # this is intentionally wrong
 
 targets:
-    - remark42:
+  - remark42:
       hosts: ["h1.example.com", "h2.example.com"]
-    staging:
+  - staging:
       inventory: "file://inventory/staging.yml"
 
 

--- a/app/config/testdata/hosts
+++ b/app/config/testdata/hosts
@@ -1,5 +1,11 @@
+# comment
+[gr1]
 hh1.example.com
 #blah blah blah
 h2.example.com:2233
-h3.example.com user1
+h3.example.com user1 #comment
 h4.example.com:2233 user2
+
+[gr2]
+h5.example.com:2233
+h6.example.com user3

--- a/app/runner/testdata/conf.yml
+++ b/app/runner/testdata/conf.yml
@@ -4,7 +4,7 @@ targets:
   remark42:
     hosts: [{host: "h1.example.com"}, {host: "h2.example.com"}]
   staging:
-    inventory_file: "testdata/inventory"
+    inventory_file: {location: "testdata/inventory"}
 
 
 tasks:

--- a/app/runner/testdata/conf2.yml
+++ b/app/runner/testdata/conf2.yml
@@ -2,7 +2,7 @@ targets:
   remark42:
     hosts: [{host: "h1.example.com"}, {host: "h2.example.com"}]
   staging:
-    inventory_file: "testdata/inventory"
+    inventory_file: {location: "testdata/inventory"}
 
 
 tasks:

--- a/spot-example.yml
+++ b/spot-example.yml
@@ -3,11 +3,11 @@ ssh_key: ~/.ssh/id_rsa
 
 targets:
   prod:
-    hosts: ["h1.example.com", "h2.example.com"]
+    hosts: [{host: "h1.example.com", port: 2222, user: "app-user"}, {host: "h2.example.com"}]
   staging:
-    inventory_file: "testdata/inventory"
+    inventory_file: {location: "testdata/inventory"}
   dev:
-    inventory_url: "http://localhost:8080/inventory"
+    inventory_url: {location: "http://localhost:8080/inventory", groups: ["dev", "test"]}
 
 tasks:
 


### PR DESCRIPTION
This PR adds support of inventory groups. Groups are optional, and "plain" (groupless) files without still supported

i.e. the oll format like this, sill valid:

```text
h1.example.com 
h2.example.com:2222
h3.example.com:2223 user2
```

in addition, ini-style groups can be defined:

```text
[gr1]
h1.example.com 
h2.example.com:2222

[gr2]
h3.example.com:2223 user2
```

PR also changes the inventory format for both `inventory_file` and `inventory_url` to support groups, i.e.

`inventory_file: {location: "testdata/inventory", groups: ["staging"]}`


