### PR TITLE
support multiple targets in cli, drop hosts override param as redundant

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ SimploTask supports the following command-line options:
   variable `$SPOT_FILE` to define the playbook file path.
 - `t`, `--task=`: Specifies the task name to execute. The task should be defined in the playbook file.
   If not specified all the tasks will be executed.
-- `-d`, `--target=`: Specifies the target name to use for the task execution. The target should be defined in the playbook file and can represent remote hosts, inventory files, or inventory URLs. If not specified the `default` target will be used. User can pass a host name or IP instead of the target name for a quick override.
+- `-d`, `--target=`: Specifies the target name to use for the task execution. The target should be defined in the playbook file and can represent remote hosts, inventory files, or inventory URLs. If not specified the `default` target will be used. User can pass a host name or IP instead of the target name for a quick override. Providing the `-d`, `--target` flag multiple times with different targets sets multiple destination targets or multiple hosts, e.g., `-d prod -d dev` or `-d example1.com -d example2.com`.
 - `-c`, `--concurrent=`: Sets the number of concurrent hosts to execute tasks. Defaults to `1`, which means hosts will be handled  sequentially.
 - `-h, --host=`: Specifies the destination host(s) for the task execution. Overrides the host(s) defined in the playbook file
   for the specified target. Providing the `-h` flag multiple times with different hosts names or ips sets multiple destination hosts,

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -36,7 +36,7 @@ func Test_runCompleted(t *testing.T) {
 		SSHKey:       "runner/testdata/test_ssh_key",
 		PlaybookFile: "runner/testdata/conf.yml",
 		TaskName:     "task1",
-		TargetName:   hostAndPort,
+		Targets:      []string{hostAndPort},
 		Only:         []string{"wait"},
 	}
 	setupLog(true)
@@ -54,7 +54,7 @@ func Test_runCompletedAllTasks(t *testing.T) {
 		SSHUser:      "test",
 		SSHKey:       "runner/testdata/test_ssh_key",
 		PlaybookFile: "runner/testdata/conf2.yml",
-		TargetName:   hostAndPort,
+		Targets:      []string{hostAndPort},
 		Dbg:          true,
 	}
 	setupLog(true)
@@ -84,7 +84,7 @@ func Test_runCanceled(t *testing.T) {
 		SSHKey:       "runner/testdata/test_ssh_key",
 		PlaybookFile: "runner/testdata/conf.yml",
 		TaskName:     "task1",
-		TargetName:   hostAndPort,
+		Targets:      []string{hostAndPort},
 		Only:         []string{"wait"},
 	}
 	setupLog(true)
@@ -108,7 +108,7 @@ func Test_runFailed(t *testing.T) {
 		SSHKey:       "runner/testdata/test_ssh_key",
 		PlaybookFile: "runner/testdata/conf-local-failed.yml",
 		TaskName:     "default",
-		TargetName:   hostAndPort,
+		Targets:      []string{hostAndPort},
 	}
 	setupLog(true)
 	err := run(opts)
@@ -121,7 +121,7 @@ func Test_runNoConfig(t *testing.T) {
 		SSHKey:       "runner/testdata/test_ssh_key",
 		PlaybookFile: "runner/testdata/conf-not-found.yml",
 		TaskName:     "task1",
-		TargetName:   "localhost",
+		Targets:      []string{"localhost"},
 		Only:         []string{"wait"},
 	}
 	setupLog(true)
@@ -138,7 +138,7 @@ func Test_connectFailed(t *testing.T) {
 		SSHKey:       "runner/testdata/test_ssh_key",
 		PlaybookFile: "runner/testdata/conf.yml",
 		TaskName:     "task1",
-		TargetName:   hostAndPort,
+		Targets:      []string{hostAndPort},
 	}
 	setupLog(true)
 	err := run(opts)


### PR DESCRIPTION
resolves #17 

The change allows passing `--target` or `-d` multiple times to run tasks for multiple target groups or target hosts. This makes `--host` option fully redundant, and I have removed it.