### PR TITLE
Removed --host from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ SimploTask supports the following command-line options:
   If not specified all the tasks will be executed.
 - `-d`, `--target=`: Specifies the target name to use for the task execution. The target should be defined in the playbook file and can represent remote hosts, inventory files, or inventory URLs. If not specified the `default` target will be used. User can pass a host name or IP instead of the target name for a quick override. Providing the `-d`, `--target` flag multiple times with different targets sets multiple destination targets or multiple hosts, e.g., `-d prod -d dev` or `-d example1.com -d example2.com`.
 - `-c`, `--concurrent=`: Sets the number of concurrent hosts to execute tasks. Defaults to `1`, which means hosts will be handled  sequentially.
-- `-h, --host=`: Specifies the destination host(s) for the task execution. Overrides the host(s) defined in the playbook file
   for the specified target. Providing the `-h` flag multiple times with different hosts names or ips sets multiple destination hosts,
   e.g., `-h example1.com -h example2.com`
 - `--inventory-file=`: Specifies the inventory file to use for the task execution. Overrides the inventory file defined in the


### PR DESCRIPTION
`--host` was removed from code in https://github.com/umputun/simplotask/pull/19, here I'm removing it from README.md