### PR TITLE
Add ability to filter set of host for the selected targed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ SimploTask supports the following command-line options:
   If not specified all the tasks will be executed.
 - `-d`, `--target=`: Specifies the target name to use for the task execution. The target should be defined in the playbook file and can represent remote hosts, inventory files, or inventory URLs. If not specified the `default` target will be used. User can pass a host name or IP instead of the target name for a quick override. Providing the `-d`, `--target` flag multiple times with different targets sets multiple destination targets or multiple hosts, e.g., `-d prod -d dev` or `-d example1.com -d example2.com`.
 - `-c`, `--concurrent=`: Sets the number of concurrent hosts to execute tasks. Defaults to `1`, which means hosts will be handled  sequentially.
-  for the specified target. Providing the `-h` flag multiple times with different hosts names or ips sets multiple destination hosts,
-  e.g., `-h example1.com -h example2.com`
+- `-h`, `--host=`: Filter destinations for the specified target. Providing the `-h` flag multiple times with different name, or hosts names or ips allow multiple destination hosts from the same target, e.g., `-h example1.com -h example2.com`
 - `--inventory-file=`: Specifies the inventory file to use for the task execution. Overrides the inventory file defined in the
   playbook file.
 - `--inventory-url=`: Specifies the inventory HTTP URL to use for the task execution. Overrides the inventory URL defined in the
@@ -59,7 +58,7 @@ SimploTask supports the following command-line options:
 - `-e`, `--env=`: Sets the environment variables to be used during the task execution. Providing the `-e` flag multiple times with different environment variables sets multiple environment variables, e.g., `-e VAR1=VALUE1 -e VAR2=VALUE2`.
 - `-v`, `--verbose`: Enables verbose mode, providing more detailed output and error messages during the task execution.
 - `--dbg`: Enables debug mode, providing even more detailed output and error messages during the task execution as well as diagnostic messages.
-- `-h`, `--help`: Displays the help message, listing all available command-line options.
+- `--help`: Displays the help message, listing all available command-line options.
 
 ## Example playbook
 
@@ -211,7 +210,7 @@ By using this approach, SimploTask enables users to write and execute more compl
 Targets are used to define the remote hosts to execute the tasks on. Targets can be defined in the playbook file or passed as a command-line argument. The following target types are supported:
 
 - `hosts`: a list of destination host names or IP addresses, with optional port and username, to execute the tasks on. Example: `hosts: [{host: "h1.example.com", user: test}, {host: "h2.example.com", "port": 2222}]`. If no user is specified, the user defined in the top section of the playbook file (or override)  will be used. If no port is specified, port 22 will be used.
-- `inventory_file`: a path to the inventory file to use and groups to use. Example: `inventory_file: {"location": "testdata/inventory", "groups": []{"gr1"} }`. If `groups` not defined all the groups will be used. The [inventory file](#inventory-file-format) contains a list of host names or IP addresses, one per line with optional `[group]` values.
+- `inventory_file`: a path to the inventory file to use and groups to use. Example: `inventory_file: {"location": "testdata/inventory", "groups": [{"gr1", "gr2"}] }`. If `groups` not defined all the groups will be used. The [inventory file](#inventory-file-format) contains a list of host names or IP addresses, one per line with optional `[group]` values.
 - `inventory_url`: a URL to the inventory file to use. Example: `inventory_url: {"location": "http://localhost:8080/inventory"}`. The response contains a list of host names or IP addresses, one per line. The same support for groups as for `inventory_file` is available.
 
 Targets contains environments each of which represents a set of hosts, for example:
@@ -225,6 +224,15 @@ targets:
   dev:
     inventory_url: {location: "http://localhost:8080/inventory", groups: ["dev", "staging"]}
 ```
+
+### Target overrides
+
+There are several ways to override or alter the target defined in the playbook file:
+
+- `--inventory-file` set hosts from the provided inventory file. Example: `--inventory-file=inventory.yml`.
+- `--inventory-url` set hosts from the provided inventory URL. Example: `--inventory-url=http://localhost:8080/inventory`.
+- `--filter`, `-i`: Set the allowed hosts using the provided name or host address. This flag acts as a filter for the hosts defined in the playbook file or inventory. For instance, if a user has a playbook file with 10 hosts but only wants to execute the tasks on 3 of them, the `--host` flag can be used to specify (filter) the desired host names and host addresses to execute the tasks on. Example usage: `--host=h1.example.com --host=h2.example.com -h=my-cool-host`.
+
 
 ### Inventory file format
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -350,19 +350,6 @@ func (p *PlayBook) filterHosts(inp []Destination, overrides *Overrides) []Destin
 	return res
 }
 
-// parseAddress parses address in format host:port and returns host and port.
-func (p *PlayBook) parseAddress(addr string) (host string, port int, err error) {
-	if !strings.Contains(addr, ":") {
-		return addr, 22, nil // default port is 22 if not set
-	}
-	elems := strings.Split(addr, ":")
-	port, err = strconv.Atoi(elems[1])
-	if err != nil {
-		return "", 0, fmt.Errorf("can't parse port %s: %w", elems[1], err)
-	}
-	return elems[0], port, nil
-}
-
 // parseInventory parses inventory yml file or url and returns a list of hosts for the specified group.
 // user is optional, if not set, it is assumed to be defined in playbook. name is optional too.
 func (p *PlayBook) parseInventory(r io.Reader, groups []string) ([]Destination, error) {

--- a/app/config/testdata/hosts-with-groups.yml
+++ b/app/config/testdata/hosts-with-groups.yml
@@ -7,3 +7,4 @@ groups:
   gr2:
     - {host: "h5.example.com", port: 2233, name: "h5"}
     - {host: "h6.example.com", user: "user3", name: "h6"}
+    - {host: "h7.example.com", user: "user3"}

--- a/app/main.go
+++ b/app/main.go
@@ -29,8 +29,9 @@ type options struct {
 	Concurrent   int      `short:"c" long:"concurrent" description:"concurrent tasks" default:"1"`
 
 	// target overrides
-	InventoryFile string `long:"inventory-file" description:"inventory file"`
-	InventoryURL  string `long:"inventory-url" description:"inventory http url"`
+	Filter        []string `short:"i" long:"filter" description:"filter target hosts"`
+	InventoryFile string   `long:"inventory-file" description:"inventory file"`
+	InventoryURL  string   `long:"inventory-url" description:"inventory http url"`
 
 	// connection overrides
 	SSHUser string `short:"u" long:"user" description:"ssh user"`
@@ -39,11 +40,12 @@ type options struct {
 	Env map[string]string `short:"e" long:"env" description:"environment variables for all commands"`
 
 	// commands filter
-	Skip []string `short:"s" long:"skip" description:"skip commands"`
-	Only []string `short:"o" long:"only" description:"run only commands"`
+	Skip []string `long:"skip" description:"skip commands"`
+	Only []string `long:"only" description:"run only commands"`
 
 	Verbose bool `short:"v" long:"verbose" description:"verbose mode"`
 	Dbg     bool `long:"dbg" description:"debug mode"`
+	Help    bool `long:"help" description:"show help"`
 }
 
 var revision = "latest"
@@ -52,13 +54,16 @@ func main() {
 	fmt.Printf("simplotask %s\n", revision)
 
 	var opts options
-	p := flags.NewParser(&opts, flags.PrintErrors|flags.PassDoubleDash|flags.HelpFlag)
+	p := flags.NewParser(&opts, flags.PrintErrors|flags.PassDoubleDash)
 	if _, err := p.Parse(); err != nil {
-		if err.(*flags.Error).Type != flags.ErrHelp {
-			os.Exit(1)
-		}
+		os.Exit(1)
+	}
+
+	if opts.Help {
+		p.WriteHelp(os.Stdout)
 		os.Exit(2)
 	}
+
 	setupLog(opts.Dbg)
 
 	if err := run(opts); err != nil {
@@ -80,6 +85,7 @@ func run(opts options) error {
 		InventoryURL:  opts.InventoryURL,
 		Environment:   opts.Env,
 		User:          opts.SSHUser,
+		FilterHosts:   opts.Filter,
 	}
 
 	conf, err := config.New(opts.PlaybookFile, &overrides)


### PR DESCRIPTION
As the user selects a target with multiple hosts (with `--target`) sometimes it is desirable to filter this list of hosts. The new parameter `--filter` `-i` allows to set host's name or host address (the flag can be repeated multiple times)

For inventory like the one below, passing `-i hh1 -i hh2 -i h4.example.com` will limit tasks execution to three hosts only, i.e. `hh1.example.com:22`, `hh2.example.com:2233` and `h4.example.com:22`

```
hosts:
  - {host: "hh1.example.com", name: "hh1"}
  - {host: "hh2.example.com", port: 2233, name: "hh2", user: "user1"}
  - {host: "h2.example.com", port: 2233, name: "h2"}
  - {host: "h3.example.com", user: "user1", name: "h3"}
  - {host: "h4.example.com", user: "user2", name: "h4"}
```

The matching first try to filter by `name` and if the filter didn't match any `name` will try to match by `host`.