### PR TITLE
Adhoc commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ SimploTask supports the following command-line options:
 - `-s`, `--skip=`: Skips the specified commands during the task execution. Providing the `-s` flag multiple times with different command names skips multiple commands.
 - `-o`, `--only=`: Runs only the specified commands during the task execution. Providing the `-o` flag multiple times with different command names runs only multiple commands.
 - `-e`, `--env=`: Sets the environment variables to be used during the task execution. Providing the `-e` flag multiple times with different environment variables sets multiple environment variables, e.g., `-e VAR1=VALUE1 -e VAR2=VALUE2`.
+- `cmd`: Executes the specified command on the remote hosts. This is useful for running an adhoc command without creating a playbook file. Should be used with the `-d` flag to specify the destination hosts. 
 - `-v`, `--verbose`: Enables verbose mode, providing more detailed output and error messages during the task execution.
 - `--dbg`: Enables debug mode, providing even more detailed output and error messages during the task execution as well as diagnostic messages.
 - `--help`: Displays the help message, listing all available command-line options.
@@ -299,6 +300,15 @@ tasks:
         delete: {"loc": "/tmp/things/{SPOT_REMOTE_USER}", "recur": true}
 
 ```
+
+## Adhoc commands
+
+SimploTask supports adhoc commands that can be executed on the remote hosts. This is useful when all is needed is to execute a command on the remote hosts without creating a playbook file. This command passed as `--cmd=<command>` flag and should always be accompanied by the `--tarbget=<host>` (`-d <host>) flags. Example: `spot --cmd="ls -la" -d h1.example.com -d h2.example.com`. 
+
+All other overrides can be used with adhoc commands as well, for example `--user`and `--key` to specify the user and sshkey to use when connecting to the remote hosts. By default, SimploTask will use the current user and the default ssh key. Inventory can be passed to such commands as well, for example `--inventory-file=inventory.yml` or `--inventory-url=http://localhost:8080/inventory` as well as `--filter` (`-f`) to filter the hosts to execute the command on.
+
+Adhoc commands always set `verbose` to `true` automatically, so the user can see the output of the command.
+
 
 ## Rolling Updates
 

--- a/app/main.go
+++ b/app/main.go
@@ -97,7 +97,7 @@ func run(opts options) error {
 	}
 
 	if opts.AdHocCmd != "" {
-		if err := adHocConf(opts, conf); err != nil {
+		if err = adHocConf(opts, conf); err != nil {
 			return fmt.Errorf("can't setup ad-hoc config: %w", err)
 		}
 	}

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -46,6 +46,21 @@ func Test_runCompleted(t *testing.T) {
 	assert.True(t, time.Since(st) >= 5*time.Second)
 }
 
+func Test_runAdhoc(t *testing.T) {
+	hostAndPort, teardown := startTestContainer(t)
+	defer teardown()
+
+	opts := options{
+		SSHUser:  "test",
+		SSHKey:   "runner/testdata/test_ssh_key",
+		Targets:  []string{hostAndPort},
+		AdHocCmd: "echo hello",
+	}
+	setupLog(true)
+	err := run(opts)
+	require.NoError(t, err)
+}
+
 func Test_runCompletedAllTasks(t *testing.T) {
 	hostAndPort, teardown := startTestContainer(t)
 	defer teardown()


### PR DESCRIPTION
This PR adds a new cli flag`--cmd`, allowing to execute a command directly on remote hosts without a playbook or inventory.

```
> spot -d dev1.umputun.dev -d dev2.umputun.dev  --cmd="ls -a /tmp"
simplotask latest
[dev1.umputun.dev:22] run task ad-hoc, commands: 1
[dev1.umputun.dev:22] > sh -c "ls -a /tmp"
[dev1.umputun.dev:22] > .
[dev1.umputun.dev:22] > ..
[dev1.umputun.dev:22] > .ICE-unix
[dev1.umputun.dev:22] > .X11-unix
[dev1.umputun.dev:22] > mc-root
[dev1.umputun.dev:22] completed ad-hoc {script: sh -c "ls -a /tmp"} (11ms)
[dev1.umputun.dev:22] completed task ad-hoc, commands: 1
[dev2.umputun.dev:22] run task ad-hoc, commands: 1
[dev2.umputun.dev:22] > sh -c "ls -a /tmp"
[dev2.umputun.dev:22] > .
[dev2.umputun.dev:22] > ..
[dev2.umputun.dev:22] > .ICE-unix
[dev2.umputun.dev:22] > .X11-unix
[dev2.umputun.dev:22] > mc-root
[dev2.umputun.dev:22] completed ad-hoc {script: sh -c "ls -a /tmp"} (11ms)
[dev2.umputun.dev:22] completed task ad-hoc, commands: 1
```

This ad-hoc command is fully integrated and works with all existing functionality of `spot`. For example, it is possible to pass a user, and key, add inventory from a file or URL, ser filters for hosts, and so on. 